### PR TITLE
add Makefile to check failed helm releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: plan terraform-plan helm-plan hplan
+
+plan: terraform-plan helm-plan
+
+terraform-plan:
+	terraform plan
+
+hplan: helm-plan
+
+helm-plan:
+	scripts/helm-plan.sh

--- a/scripts/helm-plan.sh
+++ b/scripts/helm-plan.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# fail on error
+set -e
+
+echo ""
+echo "> checking the state of the helm releases"
+helm list -A
+_count_failed_releases=$(helm list --failed -o json -A | grep -o failed | wc -l)
+echo ""
+
+if [ "$_count_failed_releases" -eq "0" ]; then
+    echo "> OK: no failed helm release found"
+    exit 0
+else
+    echo "> WARNING: found $_count_failed_releases failed helm release(s)"
+    echo "> consult the troubleshooting guide available at docs/troubleshooting.md"
+    echo ""
+    echo "> failed helm releases"
+    helm list -A --failed
+    exit 1
+fi


### PR DESCRIPTION
this is useful when planning a terraform apply and failed helm releases would not be upgraded